### PR TITLE
fix(auth): add two-factor lockout columns required by better-auth 1.6.25

### DIFF
--- a/prisma/migrations/20260807104205_two_factor_lockout_columns/migration.sql
+++ b/prisma/migrations/20260807104205_two_factor_lockout_columns/migration.sql
@@ -1,0 +1,5 @@
+-- better-auth >= 1.6.25 two-factor lockout columns. The plugin writes these
+-- on every sign-in verification; without them Prisma rejects the update and
+-- every TOTP (even valid ones) surfaces as "invalid code".
+ALTER TABLE "twoFactor" ADD COLUMN "failedVerificationCount" INTEGER DEFAULT 0;
+ALTER TABLE "twoFactor" ADD COLUMN "lockedUntil" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -265,6 +265,11 @@ model TwoFactor {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
+  // Account lockout counters required by better-auth >= 1.6.25 — the plugin
+  // updates these on every sign-in verification (even successful ones).
+  failedVerificationCount Int?      @default(0)
+  lockedUntil             DateTime?
+
   @@map("twoFactor")
 }
 


### PR DESCRIPTION
better-auth >= 1.6.25 added account lockout to the two-factor plugin and writes failedVerificationCount/lockedUntil on every sign-in verification — including successful ones. Without the columns Prisma rejected the update and every TOTP surfaced as 'invalid code'. Columns added + migration; verified the success-path update now works against the local DB.