### PR TITLE
fix(deploy): make the slug backfill runnable in the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,11 +87,15 @@ COPY --from=builder --chown=nextjs:nodejs /app/prisma.config.ts ./
 # Copy generated Prisma client
 COPY --from=builder --chown=nextjs:nodejs /app/generated ./generated
 
-# Copy tsconfig + minimal src needed for post-migration-setup.ts (runs with tsx in container)
+# Copy tsconfig + the minimal src needed by the prisma/*.ts scripts that run
+# with tsx in the container (post-migration-setup.ts, backfill-slugs.ts).
+# Anything a container-run script imports has to be listed here — the rest of
+# src/ is not in the runtime image.
 COPY --from=builder --chown=nextjs:nodejs /app/tsconfig.json ./
 COPY --from=builder --chown=nextjs:nodejs /app/src/server/db.ts ./src/server/
 COPY --from=builder --chown=nextjs:nodejs /app/src/lib/permissions.ts ./src/lib/
 COPY --from=builder --chown=nextjs:nodejs /app/src/lib/bezirke.ts ./src/lib/
+COPY --from=builder --chown=nextjs:nodejs /app/src/lib/slug.ts ./src/lib/
 
 # Trigger script for the mStudio cron job (mittwald), see the script header
 COPY --chown=nextjs:nodejs scripts/trigger-registration-closed.mjs ./scripts/

--- a/deploy/stack.yaml
+++ b/deploy/stack.yaml
@@ -28,6 +28,7 @@ services:
         sleep 5;
         done;
         node node_modules/tsx/dist/cli.mjs prisma/post-migration-setup.ts || echo "Post-migration setup failed (non-fatal)";
+        node node_modules/tsx/dist/cli.mjs prisma/backfill-slugs.ts || echo "Slug backfill failed (non-fatal)";
         exec node node_modules/next/dist/bin/next start
     volumes:
       - "uploads_data:/app/uploads"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -86,6 +86,32 @@ services:
     restart: "no"
 
   # ===========================================================================
+  # Slug Backfill (fills Post.slug / Ensemble.slug after the slug migration)
+  #
+  # Idempotent: only rows whose slug is still NULL are touched, so running it
+  # again after new content has been created is harmless.
+  #   docker compose -f docker-compose.prod.yml --profile slug-backfill up
+  # ===========================================================================
+  slug-backfill:
+    image: ghcr.io/nichtlehdev/pwr-web:${APP_IMAGE_TAG:-latest}
+    container_name: posaunenwerk-slug-backfill
+    profiles:
+      - slug-backfill
+    depends_on:
+      posaunenwerk-db:
+        condition: service_healthy
+      db-migrate:
+        condition: service_completed_successfully
+    networks:
+      - internal
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@posaunenwerk-db:5432/${POSTGRES_DB:-posaunenwerk}
+      NODE_ENV: production
+      SKIP_ENV_VALIDATION: 1
+    command: ["node", "node_modules/tsx/dist/cli.mjs", "prisma/backfill-slugs.ts"]
+    restart: "no"
+
+  # ===========================================================================
   # Database Seeding (optional, run manually)
   # ===========================================================================
   db-seed:

--- a/docs/DEPLOYMENT-CHECKLIST.md
+++ b/docs/DEPLOYMENT-CHECKLIST.md
@@ -49,16 +49,31 @@ Dieses Skript:
   pnpm prisma generate
   ```
 
-### 2b. Slug-Backfill (einmalig nach dem Slug-Deployment)
-- [ ] **Nach `migrate deploy` einmalig ausführen**:
+### 2b. Slug-Backfill
+Die Migration `20260808000051_add_post_and_ensemble_slug` legt die Spalte nur
+an — gefüllt wird sie von `prisma/backfill-slugs.ts`. Ohne den Backfill bleibt
+die Seite voll funktionsfähig (Detailseiten fallen auf die UUID zurück), aber
+die sprechenden URLs fehlen. Das Skript fasst nur Zeilen an, deren Slug noch
+`NULL` ist, und ist damit gefahrlos wiederholbar.
+
+- [ ] **mittwald**: läuft automatisch — der Startbefehl in `deploy/stack.yaml`
+  ruft das Skript nach `migrate deploy` auf. Nichts zu tun.
+- [ ] **docker-compose (Vorabversion / alter Server)**:
   ```bash
-  pnpm backfill:slugs
+  docker compose -f docker-compose.prod.yml --profile slug-backfill up
   ```
-  Die Migration `20260808000051_add_post_and_ensemble_slug` legt die Spalte
-  nur an — gefüllt wird sie von diesem Skript. Ohne den Backfill bleibt die
-  Seite voll funktionsfähig (Detailseiten fallen auf die UUID zurück), aber
-  die sprechenden URLs fehlen. Das Skript überspringt Zeilen, die schon einen
-  Slug haben, und ist damit gefahrlos wiederholbar.
+- [ ] **Manuell in einem laufenden Container**:
+  ```bash
+  docker exec -it posaunenwerk-app node node_modules/tsx/dist/cli.mjs prisma/backfill-slugs.ts
+  ```
+  Kein `pnpm` im Image — `tsx` und `prisma` sind normale Dependencies und
+  werden direkt über `node node_modules/...` aufgerufen (siehe Dockerfile).
+- [ ] **Lokal**: `pnpm backfill:slugs`
+
+> Wichtig: Skripte unter `prisma/`, die im Container laufen, dürfen nur
+> `src/`-Dateien importieren, die das Dockerfile explizit ins Runner-Image
+> kopiert. Aktuell sind das `server/db.ts`, `lib/permissions.ts`,
+> `lib/bezirke.ts` und `lib/slug.ts`.
 
 ### 3. Wichtige Änderungen seit letztem Deployment
 


### PR DESCRIPTION
prisma/backfill-slugs.ts imports @/lib/slug, but the runner image only carries the handful of src/ files the container-run scripts need — so the backfill died with MODULE_NOT_FOUND anywhere but a dev machine.

- Dockerfile copies src/lib/slug.ts alongside the existing three, with a note that this list is the constraint on what those scripts may import
- the mittwald start command runs the backfill after post-migration-setup, non-fatal and idempotent, so it needs no manual step
- docker-compose gains a slug-backfill profile for the pre-release stack
- the checklist spells out all four ways to run it

There is no pnpm in the runner on purpose (pnpm 11's runDepsStatusCheck wipes node_modules on every script invocation); tsx and prisma are regular dependencies and survive the prune, so scripts run via `node node_modules/tsx/dist/cli.mjs`.

Verified by building the production image and running the backfill from inside it against a real database: it filled the one nulled row and was a clean no-op on the second run.